### PR TITLE
Introducing better host integration for logging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,23 @@ logFactory.UseMsFactory(loggerFactory);
 
 As `LoggerFactory` implements [IDisposable](https://msdn.microsoft.com/en-us/library/system.idisposable.aspx) it must be disposed of after stopping the NServiceBus endpoint. The process for doing this will depend on how the endpoint is being hosted.
 
+### In a generic host
+
+Disposing the `LoggerFactory` is done by the underlying infrastructure.
+
+<!-- snippet: MsLoggingInGenericHost -->
+<a id='snippet-msloggingingenerichost'/></a>
+```cs
+Host.CreateDefaultBuilder()
+    .ConfigureLogging(loggingBuilder =>
+    {
+        loggingBuilder.AddConsole();
+    })
+    // should go before any other Use or Configure method that uses NServiceBus
+    .UseMicrosoftLogFactoryLogging();
+```
+<sup>[snippet source](/src/Tests/Snippets/GenericHostUsage.cs#L8-L17) / [anchor](#snippet-msloggingingenerichost)</sup>
+<!-- endsnippet -->
 
 ### In a windows service
 

--- a/readme.source.md
+++ b/readme.source.md
@@ -39,6 +39,11 @@ snippet: MsLoggingInCode
 
 As `LoggerFactory` implements [IDisposable](https://msdn.microsoft.com/en-us/library/system.idisposable.aspx) it must be disposed of after stopping the NServiceBus endpoint. The process for doing this will depend on how the endpoint is being hosted.
 
+### In a generic host
+
+Disposing the `LoggerFactory` is done by the underlying infrastructure.
+
+snippet: MsLoggingInGenericHost
 
 ### In a windows service
 

--- a/src/NServiceBus.MicrosoftLogging.Hosting/DeferredLoggerFactory.cs
+++ b/src/NServiceBus.MicrosoftLogging.Hosting/DeferredLoggerFactory.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Concurrent;
+using NServiceBus.Logging;
+
+class DeferredLoggerFactory : ILoggerFactory
+{
+    public ConcurrentDictionary<string, ConcurrentQueue<(LogLevel level, string message)>> deferredLogs = new ConcurrentDictionary<string, ConcurrentQueue<(LogLevel level, string message)>>();
+
+    public DeferredLoggerFactory(LogLevel filterLevel)
+    {
+        this.filterLevel = filterLevel;
+        isDebugEnabled = LogLevel.Debug >= filterLevel;
+        isInfoEnabled = LogLevel.Info >= filterLevel;
+        isWarnEnabled = LogLevel.Warn >= filterLevel;
+        isErrorEnabled = LogLevel.Error >= filterLevel;
+        isFatalEnabled = LogLevel.Fatal >= filterLevel;
+    }
+
+    public ILog GetLogger(Type type)
+    {
+        return GetLogger(type.FullName);
+    }
+
+    public ILog GetLogger(string name)
+    {
+        
+
+        return new NamedLogger(name, this)
+        {
+            IsDebugEnabled = isDebugEnabled,
+            IsInfoEnabled = isInfoEnabled,
+            IsWarnEnabled = isWarnEnabled,
+            IsErrorEnabled = isErrorEnabled,
+            IsFatalEnabled = isFatalEnabled
+        };
+    }
+
+    public void Write(string name, LogLevel messageLevel, string message)
+    {
+        if (messageLevel < filterLevel)
+        {
+            return;
+        }
+        var logQueues = deferredLogs.GetOrAdd(name, new ConcurrentQueue<(LogLevel level, string message)>());
+        logQueues.Enqueue((messageLevel, message));
+    }
+
+    LogLevel filterLevel;
+    bool isDebugEnabled;
+    bool isErrorEnabled;
+    bool isFatalEnabled;
+    bool isInfoEnabled;
+    bool isWarnEnabled;
+}

--- a/src/NServiceBus.MicrosoftLogging.Hosting/DeferredLoggerFactoryDefinition.cs
+++ b/src/NServiceBus.MicrosoftLogging.Hosting/DeferredLoggerFactoryDefinition.cs
@@ -1,0 +1,20 @@
+using System;
+using NServiceBus.Logging;
+
+class DeferredLoggerFactoryDefinition : LoggingFactoryDefinition
+{
+    public DeferredLoggerFactoryDefinition()
+    {
+        level = new Lazy<LogLevel>(() => LogLevel.Info);
+    }
+
+    protected override ILoggerFactory GetLoggingFactory()
+    {
+        Factory = new DeferredLoggerFactory(level.Value);
+        return Factory;
+    }
+
+    public static DeferredLoggerFactory? Factory;
+
+    Lazy<LogLevel> level;
+}

--- a/src/NServiceBus.MicrosoftLogging.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.MicrosoftLogging.Hosting/HostBuilderExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+using NServiceBus.Logging;
+
+/// <summary>
+/// Extension methods to configure NServiceBus Logging for the .NET Core generic host.
+/// </summary>
+public static class HostBuilderExtensions
+{
+    /// <summary>
+    /// Configures the host to use <see cref="MicrosoftLogFactory"/> for NServiceBus logging.
+    /// </summary>
+    /// <param name="hostBuilder"></param>
+    /// <param name="deferLogging">Intercepts all NServiceBus logging that is done before the endpoint is started and forwards them <see cref="MicrosoftLogFactory"/>.</param>
+    /// <remarks>If <paramref name="deferLogging"/> is used this extension method needs to be called before any usage of NServiceBus such as <code>UseNServiceBus</code>.</remarks>
+    public static IHostBuilder UseMicrosoftLogFactoryLogging(this IHostBuilder hostBuilder, bool deferLogging = true)
+    {
+        if (deferLogging)
+        {
+            LogManager.Use<DeferredLoggerFactoryDefinition>();
+        }
+
+        hostBuilder.ConfigureServices((ctx, serviceCollection) =>
+        {
+            serviceCollection.AddHostedService<NServiceBusLoggingHostedService>();
+        });
+
+        return hostBuilder;
+    }
+}

--- a/src/NServiceBus.MicrosoftLogging.Hosting/NServiceBus.MicrosoftLogging.Hosting.csproj
+++ b/src/NServiceBus.MicrosoftLogging.Hosting/NServiceBus.MicrosoftLogging.Hosting.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
+    <PackageReference Include="ProjectDefaults" Version="1.0.32" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.MicrosoftLogging\NServiceBus.MicrosoftLogging.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/NServiceBus.MicrosoftLogging.Hosting/NServiceBusLoggingHostedService.cs
+++ b/src/NServiceBus.MicrosoftLogging.Hosting/NServiceBusLoggingHostedService.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using MsLoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+using NServiceBus;
+using NServiceBus.Logging;
+
+class NServiceBusLoggingHostedService : IHostedService
+{
+    public NServiceBusLoggingHostedService(MsLoggerFactory loggerFactory)
+    {
+        this.loggerFactory = loggerFactory;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var logFactory = LogManager.Use<MicrosoftLogFactory>();
+        logFactory.UseMsFactory(loggerFactory);
+
+        foreach (var deferredLog in DeferredLoggerFactoryDefinition.Factory?.deferredLogs ?? 
+            new ConcurrentDictionary<string, ConcurrentQueue<(LogLevel level, string message)>>())
+        {
+            var logger = LogManager.GetLogger(deferredLog.Key);
+            foreach (var (level, message) in deferredLog.Value)
+            {
+                switch (level)
+                {
+                    case LogLevel.Debug:
+                        logger.Debug(message);
+                        break;
+                    case LogLevel.Info:
+                        logger.Info(message);
+                        break;
+                    case LogLevel.Warn:
+                        logger.Warn(message);
+                        break;
+                    case LogLevel.Error:
+                        logger.Error(message);
+                        break;
+                    case LogLevel.Fatal:
+                        logger.Fatal(message);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        DeferredLoggerFactoryDefinition.Factory?.deferredLogs.Clear();
+        DeferredLoggerFactoryDefinition.Factory = null;
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        loggerFactory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    MsLoggerFactory loggerFactory;
+}

--- a/src/NServiceBus.MicrosoftLogging.Hosting/NamedLogger.cs
+++ b/src/NServiceBus.MicrosoftLogging.Hosting/NamedLogger.cs
@@ -1,0 +1,95 @@
+using System;
+using NServiceBus.Logging;
+
+class NamedLogger : ILog
+{
+    public NamedLogger(string name, DeferredLoggerFactory defaultLoggerFactory)
+    {
+        this.name = name;
+        this.defaultLoggerFactory = defaultLoggerFactory;
+    }
+
+    public bool IsDebugEnabled { get; internal set; }
+    public bool IsInfoEnabled { get; internal set; }
+    public bool IsWarnEnabled { get; internal set; }
+    public bool IsErrorEnabled { get; internal set; }
+    public bool IsFatalEnabled { get; internal set; }
+
+    public void Debug(string message)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Debug, message);
+    }
+
+    public void Debug(string message, Exception exception)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Debug, message + Environment.NewLine + exception);
+    }
+
+    public void DebugFormat(string format, params object[] args)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, args));
+    }
+
+    public void Info(string message)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Info, message);
+    }
+
+    public void Info(string message, Exception exception)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Info, message + Environment.NewLine + exception);
+    }
+
+    public void InfoFormat(string format, params object[] args)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Info, string.Format(format, args));
+    }
+
+    public void Warn(string message)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Warn, message);
+    }
+
+    public void Warn(string message, Exception exception)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Warn, message + Environment.NewLine + exception);
+    }
+
+    public void WarnFormat(string format, params object[] args)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, args));
+    }
+
+    public void Error(string message)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Error, message);
+    }
+
+    public void Error(string message, Exception exception)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+    }
+
+    public void ErrorFormat(string format, params object[] args)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, args));
+    }
+
+    public void Fatal(string message)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Fatal, message);
+    }
+
+    public void Fatal(string message, Exception exception)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+    }
+
+    public void FatalFormat(string format, params object[] args)
+    {
+        defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, args));
+    }
+
+    DeferredLoggerFactory defaultLoggerFactory;
+    string name;
+}

--- a/src/NsbMsLogging.sln
+++ b/src/NsbMsLogging.sln
@@ -15,6 +15,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.MicrosoftLogging.Hosting", "NServiceBus.MicrosoftLogging.Hosting\NServiceBus.MicrosoftLogging.Hosting.csproj", "{17F6502A-A481-4820-B2C7-08875D12929B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Hosting", "Sample.Hosting\Sample.Hosting.csproj", "{54FCCD32-01CA-41A0-9F46-5EE1751D2ED5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +37,14 @@ Global
 		{8CB7E535-A40A-4557-BF0A-3302C12E7FC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8CB7E535-A40A-4557-BF0A-3302C12E7FC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8CB7E535-A40A-4557-BF0A-3302C12E7FC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17F6502A-A481-4820-B2C7-08875D12929B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17F6502A-A481-4820-B2C7-08875D12929B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17F6502A-A481-4820-B2C7-08875D12929B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17F6502A-A481-4820-B2C7-08875D12929B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54FCCD32-01CA-41A0-9F46-5EE1751D2ED5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54FCCD32-01CA-41A0-9F46-5EE1751D2ED5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54FCCD32-01CA-41A0-9F46-5EE1751D2ED5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54FCCD32-01CA-41A0-9F46-5EE1751D2ED5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Sample.Hosting/MyHandler.cs
+++ b/src/Sample.Hosting/MyHandler.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+class MyHandler : IHandleMessages<MyMessage>
+{
+    public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        Console.Write("Hello from MyHandler " + message.DateSend);
+        return Task.FromResult(0);
+    }
+}

--- a/src/Sample.Hosting/MyMessage.cs
+++ b/src/Sample.Hosting/MyMessage.cs
@@ -1,0 +1,7 @@
+﻿using System;
+using NServiceBus;
+
+class MyMessage:IMessage
+{
+    public DateTime DateSend { get; set; }
+}

--- a/src/Sample.Hosting/Program.cs
+++ b/src/Sample.Hosting/Program.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+
+public static class Program
+{
+    public static async Task Main()
+    {
+        using var host = CreateHostBuilder().Build();
+        await host.StartAsync();
+
+        var messageSession = host.Services.GetService<IMessageSession>();
+
+        var message = new MyMessage
+        {
+            DateSend = DateTime.Now,
+        };
+        await messageSession.SendLocal(message);
+        Console.WriteLine("\r\nPress any key to stop program\r\n");
+
+        Console.Read();
+        await host.StopAsync();
+    }
+
+    public static IHostBuilder CreateHostBuilder() =>
+        Host.CreateDefaultBuilder()
+            .ConfigureLogging(loggingBuilder =>
+            {
+                loggingBuilder.ClearProviders();
+                loggingBuilder.AddConsole();
+            })
+            .UseNServiceBusLogging() // should go first
+            .UseNServiceBus(ctx =>
+            {
+                var configuration = new EndpointConfiguration("MicrosoftLoggingSample");
+                configuration.EnableInstallers();
+                configuration.UsePersistence<InMemoryPersistence>();
+                configuration.UseTransport<LearningTransport>();
+                configuration.SendFailedMessagesTo("error");
+                return configuration;
+            });
+}

--- a/src/Sample.Hosting/Sample.Hosting.csproj
+++ b/src/Sample.Hosting/Sample.Hosting.csproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.MicrosoftLogging.Hosting\NServiceBus.MicrosoftLogging.Hosting.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.0" />
+    <PackageReference Include="ProjectDefaults" Version="1.0.32" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/src/Tests/Snippets/GenericHostUsage.cs
+++ b/src/Tests/Snippets/GenericHostUsage.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+class GenericHostUsage
+{
+    GenericHostUsage()
+    {
+        #region MsLoggingInGenericHost
+
+        Host.CreateDefaultBuilder()
+            .ConfigureLogging(loggingBuilder =>
+            {
+                loggingBuilder.AddConsole();
+            })
+            // should go before any other Use or Configure method that uses NServiceBus
+            .UseMicrosoftLogFactoryLogging();
+        #endregion
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -5,6 +5,7 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.1" />
     <PackageReference Include="Xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.ApprovalTests" Version="4.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
@@ -12,6 +13,7 @@
     <PackageReference Include="MarkdownSnippets.MsBuild" Version="17.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MarkdownSnippets.MsBuild" Version="17.0.0" PrivateAssets="All" />
+    <ProjectReference Include="..\NServiceBus.MicrosoftLogging.Hosting\NServiceBus.MicrosoftLogging.Hosting.csproj" />
     <ProjectReference Include="..\NServiceBus.MicrosoftLogging\NServiceBus.MicrosoftLogging.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.1" />


### PR DESCRIPTION
#### Description

An idea triggered by looking at https://github.com/Particular/NServiceBus.Extensions.Hosting/issues/22

Due to the static nature of the logging seam in NServiceBus customers that want to use the MS logging integration are forced to build a service provider early on which is an anti-pattern. An example is

```
Host.CreateDefaultBuilder(args)
    .ConfigureServices(services =>
    {
        var serviceProvider = services.BuildServiceProvider();

        var loggerFactory = serviceProvider.GetService<Microsoft.Extensions.Logging.ILoggerFactory>();
        var logFactory = LogManager.Use<MicrosoftLogFactory>();
        logFactory.UseMsFactory(loggerFactory);
    })
    .UseNServiceBus(...)
```

#### The solution

This introduces a dedicated package called `NServiceBus.MicrosoftLogging.Hosting` (I also considered `NServiceBus.Hosting.MicrosoftLogging`) that provides an extension method registering a hosted service that resolves the MS logging factory and configures the NServiceBus logger.

NServiceBus does logging early on when the features are initialized. In order to make sure that all log statements will consistently go to the MS logger by default a logging factory is used that intercepts the logs and defers them until the MS logger is available. This behavior can be opted out if needed. 

This is how the sample looks like with deferring enabled

![image](https://user-images.githubusercontent.com/174258/69414029-30f29c80-0d12-11ea-873c-6500c53b15ea.png)

if `.UseMicrosoftLogFactoryLogging(deferLogging: false)` is used the file logger is used until the MS logger is available, see

![image](https://user-images.githubusercontent.com/174258/69414114-64cdc200-0d12-11ea-9225-ae83da74286a.png)

![image](https://user-images.githubusercontent.com/174258/69414140-744d0b00-0d12-11ea-9bb8-35938df797a3.png)

#### Todos

 * [ ] Potentially tests if desired
 * [ ] Align on the naming of the package
 * [x] Sample
 * [ ] Documentation (will happily contribute that once I get a sense if you are willing to take this)