### PR TITLE
Change links and title

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,10 +5,11 @@ Source File: /readme.source.md
 To change this file edit the source file and then run MarkdownSnippets.
 -->
 
-# <img src="/src/icon.png" height="30px"> NServiceBus.Hyperion
+# <img src="/src/icon.png" height="30px"> NServiceBus.MicrosoftLogging
 
-[![Build status](https://ci.appveyor.com/api/projects/status/20f8p78334a1utj4/branch/master?svg=true)](https://ci.appveyor.com/project/SimonCropp/nservicebus-Hyperion)
-[![NuGet Status](https://img.shields.io/nuget/v/NServiceBus.Hyperion.svg?cacheSeconds=86400)](https://www.nuget.org/packages/NServiceBus.Hyperion/)
+[![Build status](https://ci.appveyor.com/api/projects/status/20f8p78334a1utj4/branch/master?svg=true)](https://ci.appveyor.com/project/SimonCropp/nservicebus-microsoftlogging)
+[![NuGet Status](https://img.shields.io/nuget/v/NServiceBus.MicrosoftLogging
+.svg?cacheSeconds=86400)](https://www.nuget.org/packages/NServiceBus.MicrosoftLogging/)
 
 Add support for [NServiceBus](https://particular.net/nservicebus) to log to [Microsoft.Extensions.Logging](https://github.com/aspnet/Logging).
 

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,7 @@ To change this file edit the source file and then run MarkdownSnippets.
 # <img src="/src/icon.png" height="30px"> NServiceBus.MicrosoftLogging
 
 [![Build status](https://ci.appveyor.com/api/projects/status/20f8p78334a1utj4/branch/master?svg=true)](https://ci.appveyor.com/project/SimonCropp/nservicebus-microsoftlogging)
-[![NuGet Status](https://img.shields.io/nuget/v/NServiceBus.MicrosoftLogging
-.svg?cacheSeconds=86400)](https://www.nuget.org/packages/NServiceBus.MicrosoftLogging/)
+[![NuGet Status](https://img.shields.io/nuget/v/NServiceBus.MicrosoftLogging.svg?cacheSeconds=86400)](https://www.nuget.org/packages/NServiceBus.MicrosoftLogging/)
 
 Add support for [NServiceBus](https://particular.net/nservicebus) to log to [Microsoft.Extensions.Logging](https://github.com/aspnet/Logging).
 


### PR DESCRIPTION
I had no way to verify if https://ci.appveyor.com/api/projects/status/20f8p78334a1utj4/branch/master?svg=true points to the right build status batch. But it seems the other links where wrong so I'm guessing this one probably has to be changed as well